### PR TITLE
Remove `helm push` from CI (#1140)

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -136,8 +136,3 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       # tag is set to `latest` when pushing to main branch
       run: make image.push.multiarch TAG=latest PLATFORMS="linux_amd64 linux_arm64" IMAGE=envoyproxy/gateway-dev
-
-    - name: Build and Push EG Latest Helm Chart
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      # use `0.0.0` as the default latest version.
-      run: CHART_NAME=envoy-gateway OCI_REGISTRY=oci://docker.io/envoyproxy CHART_VERSION=0.0.0 TAG=latest make helm-package helm-push


### PR DESCRIPTION
Temporaily remove helm push from CI until the repo has been created

Relates to https://github.com/envoyproxy/gateway/issues/1139